### PR TITLE
【Fixed】友達つながり機能の実装

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,18 @@
+class RelationshipsController < ApplicationController
+
+  respond_to? :js
+  def create
+    if logged_in?
+      # _follow_form.htmlからきた、idを@userに代入
+      @user = User.find(params[:relationship][:followed_id])
+      # 指定のユーザーをフォローする
+      current_user.follow!(@user)
+      # respond_to? :jsでcreate.jsに飛ばし、Ajaxで切り替える
+    end
+  end
+
+  def destroy
+    @user = Relationship.find(params[:id]).followed
+    current_user.unfollow!(@user)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,10 @@
 class UsersController < ApplicationController
   skip_before_action :login_required, only: [:new, :create]
   
+  def index
+    @user = User.all
+  end
+
   def new
     @user = User.new
   end
@@ -16,11 +20,11 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+    # @users= @user.active_relationships.all
   end
 
   private
   def user_params
-    params.require(:user).permit(:name, :email, :password,
-                                 :password_confirmation)
+    params.require(:user).permit(:name, :email, :password,:password_confirmation)
   end
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,4 @@
+class Relationship < ApplicationRecord
+  belongs_to :followed, class_name: "User"
+  belongs_to :follower, class_name: "User"
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,25 @@ class User < ApplicationRecord
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
   has_secure_password
   validates :password, length: { minimum: 6 }
+  # active_relationshipsは、自分のidがrelationshipsテーブルのfollower_idと一致するレコード
+  # つまりは自分が「フォロワーである」という関係性を取り出すアソシエーション
+  has_many :active_relationships, foreign_key: 'follower_id', class_name: 'Relationship', dependent: :destroy
+  # assive_relationshipsは、自分のidがrelationshipsテーブルのfollowed_idと一致するレコード
+  # つまりは自分が「フォローされている側である」という関係性を取り出すアソシエーション
+  has_many :passive_relationships, foreign_key: 'followed_id', class_name: 'Relationship', dependent: :destroy
+  has_many :following, through: :active_relationships, source: :followed
+  has_many :followers, through: :passive_relationships, source: :follower
+
+  # 指定のユーザーをフォローする
+  def follow!(other_user)
+    active_relationships.create!(followed_id: other_user.id)
+  end
+  # フォローしているかどうかを確認する
+  def following?(other_user)
+    active_relationships.find_by(followed_id: other_user.id)
+  end
+  # 指定のユーザーのフォローを解除する
+  def unfollow!(other_user)
+    active_relationships.find_by(followed_id: other_user.id).destroy
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
       <%= link_to "Logout", session_path(current_user.id), method: :delete %>
       <%= link_to "ブログ新規作成", new_blog_path %>
       <%= link_to "ブログ一覧", blogs_path %>
+      <%= link_to "ユーザー一覧", users_path %>
     <% else %>
       <%= link_to "Sign up", new_user_path %>
       <%= link_to "Login", new_session_path %>

--- a/app/views/relationships/create.js.erb
+++ b/app/views/relationships/create.js.erb
@@ -1,0 +1,2 @@
+<%# escape_javascriptはjの本名、jはあだ名 %>
+$("#follow_form_"+"<%= @user.id %>").html("<%= escape_javascript(render partial: 'users/follow_form', locals: { user: @user } ) %>")

--- a/app/views/relationships/destroy.js.erb
+++ b/app/views/relationships/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#follow_form_"+"<%= @user.id %>").html("<%= escape_javascript(render partial: 'users/follow_form', locals: { user: @user })%>")

--- a/app/views/users/_follow_form.html.erb
+++ b/app/views/users/_follow_form.html.erb
@@ -1,0 +1,14 @@
+<%# index.html.erbから呼び出される  %>
+<div id="follow_form_<%= user.id %>">
+  <% unless current_user.following?(user) %>
+  <%# form_withでpostリクエストを飛ばし、followed_id: user.idにフォーム内容、この場合は f.hidden_field :followed_id で取得したidをrelationships_controllerのcreateアクションに送る%>
+    <%= form_with(model: current_user.active_relationships.build(followed_id: user.id)) do |f| %>
+      <%= f.hidden_field :followed_id %>
+      <%= f.submit "フォロー" %>
+    <% end %>
+  <% else %>
+    <%= form_with(model: current_user.active_relationships.find_by(followed_id: user.id), method: :delete ) do |f| %>
+      <%= f.submit "つながりを解除" %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,8 @@
+<h2>ユーザー</h2>
+<% @user.each do |user| %>
+  <%= link_to user.name, user_path(user.id) %>
+  <%= user.email %>
+  <%# renderでテンプレートを指定して呼び出し、userインスタンスを渡している？？ %>
+  <%= render 'follow_form', user: user %>
+  <%# <% byebug %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,2 +1,22 @@
 <h1><%= @user.name %>のページ</h1>
 <p>メールアドレス: <%= @user.email %></p>
+
+<h3>フォローしている人</h3>
+<table>
+  <% @user.following.each do |following_user| %>
+    <tr>
+      <td><%= following_user.name %></td>
+      <td><%= following_user.email %></td>
+    </tr>
+  <% end %>
+</table>
+
+<h3>フォローされている人</h3>
+<table>
+  <% @user.followers.each do |followers_user| %>
+    <tr>
+      <td><%= followers_user.name %></td>
+      <td><%= followers_user.email %></td>
+    </tr>
+  <% end %>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
-  resources :blogs do
-    resources :comments
+    resources :blogs do
+      resources :comments
   end
   resources :sessions, only: [:new, :create, :destroy]
-  resources :users, only: [:new, :create, :show]
+  resources :users, only: [:new, :create, :show, :index]
+  resources :relationships, only: [:create, :destroy]
 end

--- a/db/migrate/20211030081438_create_relationships.rb
+++ b/db/migrate/20211030081438_create_relationships.rb
@@ -1,0 +1,13 @@
+class CreateRelationships < ActiveRecord::Migration[6.0]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+      t.timestamps
+    end
+
+    add_index :relationships, :follower_id
+    add_index :relationships, :followed_id
+    add_index :relationships, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_27_154028) do
+ActiveRecord::Schema.define(version: 2021_10_30_081438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,16 @@ ActiveRecord::Schema.define(version: 2021_10_27_154028) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["blog_id"], name: "index_comments_on_blog_id"
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,29 @@
 User.create!(
   name: 'oomugi',
   email: 'oomugi@gmail.com',
-  password: 'oomugi',
+  password: '111111',
+  )
+  
+User.create!(
+  name: 'komugi',
+  email: 'komugi@gmail.com',
+  password: '111111',
+  )
+
+User.create!(
+  name: 'pomugi',
+  email: 'pomugi@gmail.com',
+  password: '111111',
+  )
+
+User.create!(
+  name: 'daimugi',
+  email: 'daimugi@gmail.com',
+  password: '111111',
+  )
+
+User.create!(
+  name: 'satougi',
+  email: 'satougi@gmail.com',
+  password: '111111',
   )

--- a/test/controllers/relationships_controller_test.rb
+++ b/test/controllers/relationships_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class RelationshipsControllerTest < ActionDispatch::IntegrationTest
+  test "should get create" do
+    get relationships_create_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get relationships_destroy_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  follower_id: 1
+  followed_id: 1
+
+two:
+  follower_id: 1
+  followed_id: 1

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#11

# 友達つながり機能の実装
(friend_connection_function)

- [x] アソシエーションの定義
- [x] 同じユーザーを二度フォローできないようにする
- [x] ユーザー一覧ページを作成する。
- [x] ユーザー一覧ページのそれぞれのユーザーにフォローボタンを用意する。
- [x] フォローボタンを押すと、フォローアクションを実行する。
- [x] フォローアクションで、relationshipテーブルにフォロー関係が保存される。
- [x] フォローすると、フォローしている人一覧にフォローした人が表示される。